### PR TITLE
Limit resizable textarea to 50% of viewport

### DIFF
--- a/src/components/AutoResizingTextarea.tsx
+++ b/src/components/AutoResizingTextarea.tsx
@@ -9,10 +9,10 @@ export const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, TextareaProp
       minH="unset"
       overflow="hidden"
       w="100%"
+      maxH="50vh"
       resize="none"
       ref={ref}
       minRows={1}
-      maxRows={15}
       as={ResizeTextarea}
       {...props}
     />


### PR DESCRIPTION
From https://github.com/tarasglek/private.overthinker.dev/pull/5#issuecomment-1519635405:

> This also added a feature where the height of input box now has a max limit..which is something i wanted before. Would be nice if we could make the height limit be 50%

This sets a `max-height` on the resizable textarea to `50vh` instead of specifying the `maxRows` prop.